### PR TITLE
fix DepartmentMapper.java method names

### DIFF
--- a/src/main/java/pl/piomin/services/department/mapper/DepartmentMapper.java
+++ b/src/main/java/pl/piomin/services/department/mapper/DepartmentMapper.java
@@ -8,6 +8,6 @@ import pl.piomin.services.department.model.Department;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface DepartmentMapper {
-    DepartmentDTO departmentToEmployeeDTO(Department department);
-    Department departmentDTOToEmployee(DepartmentDTO departmentDTO);
+    DepartmentDTO departmentToDepartmentDTO(Department department);
+    Department departmentDTOToDepartment(DepartmentDTO departmentDTO);
 }


### PR DESCRIPTION
The method names didn't reflect the actual mapping. I believe they are a leftover of a copy/paste.